### PR TITLE
Support for Symfony 6.4 and attributes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         }
     },
     "require": {
-        "php": "8.0.*|8.1.*",
+        "php": "^8.0",
         "jms/serializer-bundle": "~4.0",
         "symfony/config": "~5.0",
         "symfony/dependency-injection": "~5.0",

--- a/composer.json
+++ b/composer.json
@@ -28,20 +28,20 @@
     "require": {
         "php": "^8.0",
         "jms/serializer-bundle": "^5.4",
-        "symfony/config": "~5.0",
-        "symfony/dependency-injection": "~5.0",
-        "symfony/http-kernel": "~5.0",
-        "symfony/routing": "~5.0",
-        "symfony/yaml": "~5.0",
+        "symfony/config": "6.4.*",
+        "symfony/dependency-injection": "6.4.*",
+        "symfony/http-kernel": "6.4.*",
+        "symfony/routing": "6.4.*",
+        "symfony/yaml": "6.4.*",
         "teqneers/ext-direct": "^5.0",
         "twig/twig": "~3.3"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",
-        "symfony/framework-bundle": "~5.0",
-        "symfony/phpunit-bridge": "~5.0",
-        "symfony/security-bundle": "~5.0",
-        "symfony/templating": "~5.0"
+        "symfony/framework-bundle": "6.4.*",
+        "symfony/phpunit-bridge": "6.4.*",
+        "symfony/security-bundle": "6.4.*",
+        "symfony/templating": "6.4.*"
     },
     "extra": {
         "branch-alias": {

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     },
     "require": {
         "php": "^8.0",
-        "jms/serializer-bundle": "~4.0",
+        "jms/serializer-bundle": "^5.4",
         "symfony/config": "~5.0",
         "symfony/dependency-injection": "~5.0",
         "symfony/http-kernel": "~5.0",

--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,7 @@
         "twig/twig": "~3.3"
     },
     "require-dev": {
+        "koriym/attributes": "^1.0",
         "phpunit/phpunit": "^9.5",
         "symfony/framework-bundle": "6.4.*",
         "symfony/phpunit-bridge": "6.4.*",

--- a/src/Controller/RouterController.php
+++ b/src/Controller/RouterController.php
@@ -44,7 +44,7 @@ class RouterController
      */
     public function routerAction($endpoint, Request $request)
     {
-        $request->setRequestFormat($request->getContentType());
+        $request->setRequestFormat($request->getContentTypeFormat());
 
         if ($request->getMethod() !== Request::METHOD_POST) {
             throw new MethodNotAllowedHttpException(array(Request::METHOD_POST));

--- a/src/DependencyInjection/Compiler/AddExtDirectServicePass.php
+++ b/src/DependencyInjection/Compiler/AddExtDirectServicePass.php
@@ -21,7 +21,7 @@ class AddExtDirectServicePass implements CompilerPassInterface
     /**
      * {@inheritdoc}
      */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         $tagName         = 'tq_extdirect.service';
         $defaultEndpoint = $container->getParameter('tq_extdirect.endpoint.default');

--- a/src/DependencyInjection/Compiler/ValidateSecurityPass.php
+++ b/src/DependencyInjection/Compiler/ValidateSecurityPass.php
@@ -24,7 +24,7 @@ class ValidateSecurityPass implements CompilerPassInterface
     /**
      * {@inheritdoc}
      */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (!$container->hasDefinition('tq_extdirect.router.authorization_checker')) {
             // authorization listener not enabled or expression language not available

--- a/src/DependencyInjection/TQExtDirectExtension.php
+++ b/src/DependencyInjection/TQExtDirectExtension.php
@@ -31,7 +31,7 @@ class TQExtDirectExtension extends Extension
     /**
      * {@inheritdoc}
      */
-    public function load(array $config, ContainerBuilder $container)
+    public function load(array $config, ContainerBuilder $container): void
     {
         $loader = new YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('extdirect.yml');

--- a/src/Resources/config/extdirect.yml
+++ b/src/Resources/config/extdirect.yml
@@ -2,6 +2,9 @@ parameters:
     tq_extdirect.debug: false
 
 services:
+    Doctrine\Common\Annotations\AnnotationReader:
+    annotation_reader: '@Doctrine\Common\Annotations\AnnotationReader'
+
     tq_extdirect.ext_direct_api_controller:
         class: TQ\Bundle\ExtDirectBundle\Controller\ApiController
         public: true

--- a/src/Resources/config/extdirect.yml
+++ b/src/Resources/config/extdirect.yml
@@ -2,9 +2,6 @@ parameters:
     tq_extdirect.debug: false
 
 services:
-    Doctrine\Common\Annotations\AnnotationReader:
-    annotation_reader: '@Doctrine\Common\Annotations\AnnotationReader'
-
     tq_extdirect.ext_direct_api_controller:
         class: TQ\Bundle\ExtDirectBundle\Controller\ApiController
         public: true

--- a/src/TQExtDirectBundle.php
+++ b/src/TQExtDirectBundle.php
@@ -26,7 +26,7 @@ class TQExtDirectBundle extends Bundle
     /**
      * {@inheritdoc}
      */
-    public function build(ContainerBuilder $container)
+    public function build(ContainerBuilder $container): void
     {
         parent::build($container);
 

--- a/tests/Services/Service1.php
+++ b/tests/Services/Service1.php
@@ -18,16 +18,16 @@ use TQ\ExtDirect\Annotation as Direct;
  *
  * @Direct\Action()
  */
+#[Direct\Action()]
 class Service1
 {
     /**
      * @Direct\Method()
      * @Direct\Parameter("a", { @Assert\NotNull(), @Assert\Type("string") })
-     *
-     * @param string $a
-     * @return string
      */
-    public function methodA($a)
+    #[Direct\Method()]
+    #[Direct\Parameter("a", [ new Assert\NotNull(), new Assert\Type("string") ])]
+    public function methodA(string $a): string
     {
         return $a;
     }

--- a/tests/Services/Sub/Service1.php
+++ b/tests/Services/Sub/Service1.php
@@ -18,16 +18,16 @@ use TQ\ExtDirect\Annotation as Direct;
  *
  * @Direct\Action("app.direct.test1")
  */
+#[Direct\Action("app.direct.test1")]
 class Service1
 {
     /**
      * @Direct\Method()
      * @Direct\Parameter("a", { @Assert\NotNull(), @Assert\Type("string") })
-     *
-     * @param string $a
-     * @return string
      */
-    public function methodA($a)
+    #[Direct\Method()]
+    #[Direct\Parameter("a", [ new Assert\NotNull(), new Assert\Type("string") ])]
+    public function methodA(string $a): string
     {
         return $a;
     }

--- a/tests/TQExtDirectBundleTest.php
+++ b/tests/TQExtDirectBundleTest.php
@@ -173,10 +173,7 @@ OUT
 
 class AppKernel extends Kernel
 {
-    /**
-     * @return iterable<mixed, BundleInterface>
-     */
-    public function registerBundles()
+    public function registerBundles(): \Traversable|array
     {
         return array(
             new FrameworkBundle(),
@@ -188,23 +185,17 @@ class AppKernel extends Kernel
     /**
      * {@inheritdoc}
      */
-    public function registerContainerConfiguration(LoaderInterface $loader)
+    public function registerContainerConfiguration(LoaderInterface $loader): void
     {
         $loader->load(__DIR__ . '/TQExtDirectBundleTestConfig.yml');
     }
 
-    /**
-     * @return string
-     */
-    public function getCacheDir()
+    public function getCacheDir(): string
     {
         return sys_get_temp_dir() . '/ext-direct-bundle/cache';
     }
 
-    /**
-     * @return string
-     */
-    public function getLogDir()
+    public function getLogDir(): string
     {
         return sys_get_temp_dir() . '/ext-direct-bundle/log';
     }

--- a/tests/TQExtDirectBundleTestConfig.yml
+++ b/tests/TQExtDirectBundleTestConfig.yml
@@ -30,3 +30,6 @@ services:
         class: TQ\Bundle\ExtDirectBundle\Tests\Services\Service1
         tags:
             - { name: tq_extdirect.service, endpoint: api }
+
+    Doctrine\Common\Annotations\AnnotationReader:
+    annotation_reader: '@Doctrine\Common\Annotations\AnnotationReader'

--- a/tests/TQExtDirectBundleTestConfig.yml
+++ b/tests/TQExtDirectBundleTestConfig.yml
@@ -2,10 +2,20 @@ framework:
     secret: "Three can keep a secret, if two of them are dead."
     validation:
         enabled: true
+        email_validation_mode: html5
     router:
         resource: "%kernel.project_dir%/tests/TQExtDirectBundleTestRouting.yml"
         strict_requirements: ~
         utf8: true
+
+    http_method_override: false
+    handle_all_throwables: true
+
+    php_errors:
+        log: true
+
+    annotations:
+        enabled: false
 
 tq_ext_direct:
     endpoints:

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -11,4 +11,6 @@ use Doctrine\Common\Annotations\AnnotationRegistry;
 
 $loader = require __DIR__ . '/../vendor/autoload.php';
 
-AnnotationRegistry::registerLoader(array($loader, 'loadClass'));
+if (method_exists(AnnotationRegistry::class, 'registerLoader')) {
+    AnnotationRegistry::registerLoader([$loader, 'loadClass']);
+}


### PR DESCRIPTION
Tested with PHP 8.2.x. All tests passed (needs my forked ext-direct branch https://github.com/middlebrain/ext-direct/tree/attribute-support).

There are two Symfony 6.4 deprecations left:
```
  1x: Since symfony/templating 6.4: "Symfony\Component\Templating\Helper\Helper" is deprecated since version 6.4 and will be removed in 7.0. Use Twig instead.
    1x in TQExtDirectBundleTest::testServiceDescription from TQ\Bundle\ExtDirectBundle\Tests

  1x: Since symfony/templating 6.4: "Symfony\Component\Templating\Helper\HelperInterface" is deprecated since version 6.4 and will be removed in 7.0. Use Twig instead.
    1x in TQExtDirectBundleTest::testServiceDescription from TQ\Bundle\ExtDirectBundle\Tests
```
I don't know, how to fix this.

If you replace 
```
    Doctrine\Common\Annotations\AnnotationReader:
    annotation_reader: '@Doctrine\Common\Annotations\AnnotationReader'
```
with
```
    Koriym\Attributes\AttributeReader:
    annotation_reader: '@Koriym\Attributes\AttributeReader'
```
in
```
tests/TQExtDirectBundleTestConfig.yml
```
then the attribute tests will pass too.

I don't know how to integrate the attribute tests into the test suite.
